### PR TITLE
fix: remove all relative_font_size instances

### DIFF
--- a/android/src/toga_android/fonts.py
+++ b/android/src/toga_android/fonts.py
@@ -7,8 +7,6 @@ from org.beeware.android import MainActivity
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -116,15 +114,6 @@ class Font:
             and self.interface.size in ABSOLUTE_FONT_SIZES
         ):
             default = base_size * FONT_SIZE_SCALE.get(self.interface.size, 1.0)
-            return default
-        elif (
-            isinstance(self.interface.size, str)
-            and self.interface.size in RELATIVE_FONT_SIZES
-        ):
-            parent_size = getattr(self.interface, "_parent_size", default)
-            default = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
-                self.interface.size, 1.0
-            )
             return default
         else:
             # Using SP means we follow the standard proportion between CSS pixels and

--- a/android/tests_backend/fonts.py
+++ b/android/tests_backend/fonts.py
@@ -80,16 +80,20 @@ class FontMixin:
 
     def assert_font_size(self, expected):
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
-            expected = self.default_font_size * (72 / 96)
+            expected = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                self.default_font_size,
+                self.native.getResources().getDisplayMetrics(),
+            )
         elif isinstance(expected, str):
             expected = self.default_font_size * FONT_SIZE_SCALE.get(expected, 1.0)
-        assert round(self.text_size) == round(
-            TypedValue.applyDimension(
+        else:
+            expected = TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_SP,
                 expected * (96 / 72),
                 self.native.getResources().getDisplayMetrics(),
             )
-        )
+        assert round(self.text_size) == round(expected)
 
     def assert_font_family(self, expected):
         if not SYSTEM_FONTS:

--- a/android/tests_backend/fonts.py
+++ b/android/tests_backend/fonts.py
@@ -8,8 +8,6 @@ from java import jint
 from java.lang import Integer, Long
 from travertino.constants import (
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -81,30 +79,17 @@ class FontMixin:
             assert NORMAL == variant
 
     def assert_font_size(self, expected):
-        base_size = 14
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
-            expected = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_SP,
-                self.default_font_size,
-                self.native.getResources().getDisplayMetrics(),
-            )
+            expected = self.default_font_size * (72 / 96)
         elif isinstance(expected, str):
-            if expected in RELATIVE_FONT_SIZES:
-                parent_size = getattr(self, "_parent_size", base_size)
-                expected = TypedValue.applyDimension(
-                    TypedValue.COMPLEX_UNIT_SP,
-                    parent_size * RELATIVE_FONT_SIZE_SCALE.get(expected, 1.0),
-                    self.native.getResources().getDisplayMetrics(),
-                )
-            else:
-                expected = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
-        else:
-            expected = TypedValue.applyDimension(
+            expected = self.default_font_size * FONT_SIZE_SCALE.get(expected, 1.0)
+        assert round(self.text_size) == round(
+            TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_SP,
                 expected * (96 / 72),
                 self.native.getResources().getDisplayMetrics(),
             )
-        assert round(self.text_size) == round(expected)
+        )
 
     def assert_font_family(self, expected):
         if not SYSTEM_FONTS:

--- a/changes/1814.misc.rst
+++ b/changes/1814.misc.rst
@@ -1,1 +1,1 @@
-Added support for CSS font size keywords in Android, Cocoa, GTK, iOS, and Windows.
+Added support for absolute CSS font size keywords in Android, Cocoa, GTK, iOS, and Windows.

--- a/cocoa/src/toga_cocoa/fonts.py
+++ b/cocoa/src/toga_cocoa/fonts.py
@@ -4,8 +4,6 @@ from fontTools.ttLib import TTFont
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -105,16 +103,7 @@ class Font:
             ):
                 base_size = NSFont.systemFontSize
                 font_size = base_size * FONT_SIZE_SCALE.get(self.interface.size, 1.0)
-            elif (
-                isinstance(self.interface.size, str)
-                and self.interface.size in RELATIVE_FONT_SIZES
-            ):
-                parent_size = getattr(
-                    self.interface, "_parent_size", NSFont.systemFontSize
-                )
-                font_size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
-                    self.interface.size, 1.0
-                )
+
             else:
                 # A "point" in Apple APIs is equivalent to a CSS pixel, but the Toga
                 # public API works in CSS points, which are slightly larger

--- a/cocoa/tests_backend/fonts.py
+++ b/cocoa/tests_backend/fonts.py
@@ -1,7 +1,5 @@
 from travertino.constants import (
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -55,14 +53,7 @@ class FontMixin:
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
             assert self.font.pointSize == 13
         elif isinstance(expected, str):
-            base_size = 13
-            if expected in RELATIVE_FONT_SIZES:
-                parent_size = getattr(self, "_parent_size", base_size)
-                expected_size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
-                    expected, 1.0
-                )
-            else:
-                expected_size = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
+            expected_size = 13 * FONT_SIZE_SCALE.get(expected, 1.0)
             assert abs(self.font.pointSize - expected_size) < 0.01
         else:
             assert self.font.pointSize == expected * 96 / 72

--- a/core/src/toga/fonts.py
+++ b/core/src/toga/fonts.py
@@ -14,7 +14,6 @@ from travertino.constants import (
     MONOSPACE,
     NORMAL,
     OBLIQUE,
-    RELATIVE_FONT_SIZES,
     SANS_SERIF,
     SERIF,
     SMALL_CAPS,
@@ -65,9 +64,7 @@ class Font(BaseFont):
             "default size"
             if self.size == SYSTEM_DEFAULT_FONT_SIZE
             else (
-                f"{self.size}"
-                if self.size in ABSOLUTE_FONT_SIZES or self.size in RELATIVE_FONT_SIZES
-                else f"{self.size}pt"
+                f"{self.size}" if self.size in ABSOLUTE_FONT_SIZES else f"{self.size}pt"
             )
         )
         weight = f" {self.weight}" if self.weight != NORMAL else ""

--- a/core/src/toga/style/pack.py
+++ b/core/src/toga/style/pack.py
@@ -24,7 +24,6 @@ from travertino.constants import (  # noqa: F401
     NONE,
     NORMAL,
     OBLIQUE,
-    RELATIVE_FONT_SIZES,
     RIGHT,
     ROW,
     RTL,
@@ -111,7 +110,6 @@ class Pack(BaseStyle):
     font_weight: str = validated_property(*FONT_WEIGHTS, initial=NORMAL)
     font_size: int | str = validated_property(
         *ABSOLUTE_FONT_SIZES,
-        *RELATIVE_FONT_SIZES,
         integer=True,
         initial=SYSTEM_DEFAULT_FONT_SIZE,
     )
@@ -937,9 +935,9 @@ class Pack(BaseStyle):
             else:
                 css.append(f"font-family: {self.font_family};")
         if self.font_size != SYSTEM_DEFAULT_FONT_SIZE:
-            if isinstance(self.font_size, str) and (
-                self.font_size in ABSOLUTE_FONT_SIZES
-                or self.font_size in RELATIVE_FONT_SIZES
+            if (
+                isinstance(self.font_size, str)
+                and self.font_size in ABSOLUTE_FONT_SIZES
             ):
                 css.append(f"font-size: {self.font_size};")
             else:

--- a/core/tests/style/pack/test_css.py
+++ b/core/tests/style/pack/test_css.py
@@ -450,11 +450,6 @@ from toga.style.pack import (
             id="font-size",
         ),
         pytest.param(
-            Pack(font_size="smaller"),
-            "flex-direction: row; flex: 0.0 0 auto; font-size: smaller;",
-            id="font-size-smaller",
-        ),
-        pytest.param(
             Pack(font_size="small"),
             "flex-direction: row; flex: 0.0 0 auto; font-size: small;",
             id="font-size-small",

--- a/core/tests/test_fonts.py
+++ b/core/tests/test_fonts.py
@@ -158,24 +158,6 @@ def app():
             NORMAL,
             "system x-large",
         ),
-        # Custom font, smaller size
-        (
-            "Custom Font",
-            "smaller",
-            NORMAL,
-            NORMAL,
-            NORMAL,
-            "Custom Font smaller",
-        ),
-        # Custom font, larger size
-        (
-            "Custom Font",
-            "larger",
-            NORMAL,
-            NORMAL,
-            NORMAL,
-            "Custom Font larger",
-        ),
     ],
 )
 def test_builtin_font(family, size, weight, style, variant, as_str):

--- a/docs/reference/style/pack.rst
+++ b/docs/reference/style/pack.rst
@@ -289,8 +289,7 @@ The weight of the font to be used.
 
 **Values:**
     - ``<integer>`` (in :ref:`CSS points <css-units>`)
-    - Absolute keywords: ``xx-small`` | ``x-small`` | ``small`` | ``medium`` | ``large`` | ``x-large`` | ``xx-large`` | ``xxx-large``
-    - Relative keywords: ``larger`` | ``smaller``
+    - Absolute keywords: ``xx-small`` | ``x-small`` | ``small`` | ``medium`` | ``large`` | ``x-large`` | ``xx-large``
 
 **Initial value:** System default
 
@@ -298,7 +297,6 @@ The size of the font to be used. Can be specified in three ways:
 
 * An integer value in :ref:`CSS points <css-units>`
 * An absolute size keyword, which sets the size relative to the system's base font size
-* A relative size keyword, which adjusts the size relative to the parent element's font size
 
 The relationship between Pack and CSS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gtk/src/toga_gtk/fonts.py
+++ b/gtk/src/toga_gtk/fonts.py
@@ -3,7 +3,6 @@ from warnings import warn
 
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -88,7 +87,6 @@ class Font:
             if (
                 self.interface.size != SYSTEM_DEFAULT_FONT_SIZE
                 and self.interface.size not in ABSOLUTE_FONT_SIZES
-                and self.interface.size not in RELATIVE_FONT_SIZES
             ):
                 font.set_size(self.interface.size * Pango.SCALE)
 

--- a/gtk/src/toga_gtk/libs/styles.py
+++ b/gtk/src/toga_gtk/libs/styles.py
@@ -1,6 +1,5 @@
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.colors import TRANSPARENT
@@ -67,7 +66,7 @@ def get_font_css(value):
     }
 
     # If value is an absolute or relative keyword, use those to set size instead
-    if value.size in ABSOLUTE_FONT_SIZES or value.size in RELATIVE_FONT_SIZES:
+    if value.size in ABSOLUTE_FONT_SIZES:
         style["font-size"] = f"{value.size}"
     elif value.size != SYSTEM_DEFAULT_FONT_SIZE:
         style["font-size"] = f"{value.size}pt"

--- a/gtk/tests_backend/fonts.py
+++ b/gtk/tests_backend/fonts.py
@@ -1,8 +1,6 @@
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -39,15 +37,6 @@ class FontMixin:
         elif expected in ABSOLUTE_FONT_SIZES:
             scale = FONT_SIZE_SCALE.get(expected, 1.0)
             assert 8 * scale < int(self.font.get_size() / Pango.SCALE) < 18 * scale
-        elif expected in RELATIVE_FONT_SIZES:
-            parent_size = getattr(
-                self, "_parent_size", self.font.get_size() / Pango.SCALE
-            )
-            scale = RELATIVE_FONT_SIZE_SCALE.get(expected, 1.0)
-            expected = parent_size * scale
-            assert (
-                abs(expected - int(self.font.get_size() / Pango.SCALE)) <= 5
-            )  # Same as checking 8 to 18
         else:
             assert int(self.font.get_size() / Pango.SCALE) == expected
 

--- a/iOS/src/toga_iOS/fonts.py
+++ b/iOS/src/toga_iOS/fonts.py
@@ -4,8 +4,6 @@ from fontTools.ttLib import TTFont
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -102,17 +100,7 @@ class Font:
                 isinstance(self.interface.size, str)
                 and self.interface.size in ABSOLUTE_FONT_SIZES
             ):
-                base_size = UIFont.labelFontSize
-                size = base_size * FONT_SIZE_SCALE.get(self.interface.size, 1.0)
-            elif (
-                isinstance(self.interface.size, str)
-                and self.interface.size in RELATIVE_FONT_SIZES
-            ):
-                # Get the parent's font size, or use MEDIUM as fallback
-                parent_size = getattr(
-                    self.interface, "_parent_size", UIFont.labelFontSize
-                )
-                size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
+                size = UIFont.labelFontSize * FONT_SIZE_SCALE.get(
                     self.interface.size, 1.0
                 )
             else:

--- a/iOS/tests_backend/fonts.py
+++ b/iOS/tests_backend/fonts.py
@@ -1,7 +1,5 @@
 from travertino.constants import (
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -58,16 +56,7 @@ class FontMixin:
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
             assert self.font.pointSize == 17
         elif isinstance(expected, str):
-            base_size = 17
-            if expected in RELATIVE_FONT_SIZES:
-                # For relative sizes, we need to know the parent size
-                # In tests, assume MEDIUM as the parent size if not specified
-                parent_size = getattr(self, "_parent_size", base_size)
-                expected_size = parent_size * RELATIVE_FONT_SIZE_SCALE.get(
-                    expected, 1.0
-                )
-            else:
-                expected_size = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
+            expected_size = 17 * FONT_SIZE_SCALE.get(expected, 1.0)
             assert abs(self.font.pointSize - expected_size) < 0.01
         else:
             assert self.font.pointSize == expected * 96 / 72

--- a/testbed/tests/test_fonts.py
+++ b/testbed/tests/test_fonts.py
@@ -3,7 +3,6 @@ from importlib import import_module
 import pytest
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
-    RELATIVE_FONT_SIZES,
 )
 
 import toga
@@ -61,7 +60,6 @@ async def test_font_options(widget: toga.Label, font_probe):
             20,
             SYSTEM_DEFAULT_FONT_SIZE,
             *ABSOLUTE_FONT_SIZES,
-            *RELATIVE_FONT_SIZES,
         ]:
             for font_weight in FONT_WEIGHTS:
                 for font_style in FONT_STYLES:

--- a/travertino/src/travertino/constants.py
+++ b/travertino/src/travertino/constants.py
@@ -90,7 +90,6 @@ MEDIUM = "medium"
 LARGE = "large"
 X_LARGE = "x-large"
 XX_LARGE = "xx-large"
-XXX_LARGE = "xxx-large"
 
 ABSOLUTE_FONT_SIZES = {
     XX_SMALL,
@@ -100,13 +99,7 @@ ABSOLUTE_FONT_SIZES = {
     LARGE,
     X_LARGE,
     XX_LARGE,
-    XXX_LARGE,
 }
-
-LARGER = "larger"
-SMALLER = "smaller"
-
-RELATIVE_FONT_SIZES = {LARGER, SMALLER}
 
 FONT_SIZE_SCALE_FACTOR = 1.2
 
@@ -118,12 +111,6 @@ FONT_SIZE_SCALE = {
     LARGE: 1.2,
     X_LARGE: 1.5,
     XX_LARGE: 2.0,
-    XXX_LARGE: 3.0,
-}
-
-RELATIVE_FONT_SIZE_SCALE = {
-    LARGER: FONT_SIZE_SCALE_FACTOR,  # 20% larger
-    SMALLER: 1 / FONT_SIZE_SCALE_FACTOR,  # 20% smaller
 }
 
 ######################################################################

--- a/travertino/src/travertino/fonts.py
+++ b/travertino/src/travertino/fonts.py
@@ -7,7 +7,6 @@ from .constants import (
     ITALIC,
     NORMAL,
     OBLIQUE,
-    RELATIVE_FONT_SIZES,
     SMALL_CAPS,
     SYSTEM_DEFAULT_FONT_SIZE,
 )
@@ -28,10 +27,7 @@ class Font:
             try:
                 if size.strip().endswith("pt"):
                     self.size = int(size[:-2])
-                elif (
-                    size.strip() in ABSOLUTE_FONT_SIZES
-                    or size.strip() in RELATIVE_FONT_SIZES
-                ):
+                elif size.strip() in ABSOLUTE_FONT_SIZES:
                     self.size = size.strip()
                 else:
                     raise ValueError(f"Invalid font size {size!r}")

--- a/travertino/tests/test_fonts.py
+++ b/travertino/tests/test_fonts.py
@@ -5,20 +5,16 @@ from travertino.constants import (
     BOLD,
     ITALIC,
     LARGE,
-    LARGER,
     MEDIUM,
     NORMAL,
     OBLIQUE,
-    RELATIVE_FONT_SIZES,
     SMALL,
     SMALL_CAPS,
-    SMALLER,
     SYSTEM_DEFAULT_FONT_SIZE,
     X_LARGE,
     X_SMALL,
     XX_LARGE,
     XX_SMALL,
-    XXX_LARGE,
 )
 from travertino.fonts import Font
 
@@ -101,16 +97,13 @@ def test_simple_construction(size):
         LARGE,
         X_LARGE,
         XX_LARGE,
-        XXX_LARGE,
-        LARGER,
-        SMALLER,
     ],
 )
 def test_css_font_size_keywords(size):
     font = Font("Comic Sans", size)
     assert_font(font, "Comic Sans", size, NORMAL, NORMAL, NORMAL)
     assert isinstance(font.size, str)
-    assert font.size in ABSOLUTE_FONT_SIZES or font.size in RELATIVE_FONT_SIZES
+    assert font.size in ABSOLUTE_FONT_SIZES
 
 
 @pytest.mark.parametrize(
@@ -123,9 +116,6 @@ def test_css_font_size_keywords(size):
         (LARGE, "<Font: large Comic Sans>"),
         (X_LARGE, "<Font: x-large Comic Sans>"),
         (XX_LARGE, "<Font: xx-large Comic Sans>"),
-        (XXX_LARGE, "<Font: xxx-large Comic Sans>"),
-        (LARGER, "<Font: larger Comic Sans>"),
-        (SMALLER, "<Font: smaller Comic Sans>"),
     ],
 )
 def test_css_font_size_repr(size, expected_repr):

--- a/winforms/src/toga_winforms/fonts.py
+++ b/winforms/src/toga_winforms/fonts.py
@@ -11,8 +11,6 @@ from System.Runtime.InteropServices import ExternalException
 from travertino.constants import (
     ABSOLUTE_FONT_SIZES,
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
     SYSTEM_DEFAULT_FONT_SIZE,
 )
 
@@ -105,12 +103,6 @@ class Font:
             ):
                 font_size = DEFAULT_FONT.Size
                 font_size *= FONT_SIZE_SCALE.get(self.interface.size, 1.0)
-            elif (
-                isinstance(self.interface.size, str)
-                and self.interface.size in RELATIVE_FONT_SIZES
-            ):
-                font_size = getattr(self.interface, "_parent_size", DEFAULT_FONT.Size)
-                font_size *= RELATIVE_FONT_SIZE_SCALE.get(self.interface.size, 1.0)
             else:
                 font_size = self.interface.size
 

--- a/winforms/tests_backend/fonts.py
+++ b/winforms/tests_backend/fonts.py
@@ -1,8 +1,6 @@
 from System.Drawing import FontFamily, SystemFonts
 from travertino.constants import (
     FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZE_SCALE,
-    RELATIVE_FONT_SIZES,
 )
 
 from toga.fonts import (
@@ -52,12 +50,7 @@ class FontMixin:
         if expected == SYSTEM_DEFAULT_FONT_SIZE:
             expected = 9.0
         elif isinstance(expected, str):
-            base_size = 9.0
-            if expected in RELATIVE_FONT_SIZES:
-                parent_size = getattr(self, "_parent_size", base_size)
-                expected = parent_size * RELATIVE_FONT_SIZE_SCALE.get(expected, 1.0)
-            else:
-                expected = base_size * FONT_SIZE_SCALE.get(expected, 1.0)
+            expected = 9.0 * FONT_SIZE_SCALE.get(expected, 1.0)
         assert abs(self.font.SizeInPoints - expected) < 0.1
 
     def assert_font_family(self, expected):


### PR DESCRIPTION
Removes the references to `RELATIVE_FONT_SIZE` in docs and throughout codebase.